### PR TITLE
Potential fix for code scanning alert no. 102: Code injection

### DIFF
--- a/buggy_python_code.py
+++ b/buggy_python_code.py
@@ -22,10 +22,17 @@ def print_nametag(format_string, person):
 
 
 def fetch_website(urllib_version, url):
-    # Import the requested version (2 or 3) of urllib
-    exec(f"import urllib{urllib_version} as urllib", globals())
+    # Map valid versions to their corresponding modules
+    urllib_modules = {
+        "2": "urllib2",
+        "3": "urllib3"
+    }
+    # Validate the requested version
+    if urllib_version not in urllib_modules:
+        raise ValueError(f"Invalid urllib version: {urllib_version}")
+    # Dynamically import the requested module
+    urllib = __import__(urllib_modules[urllib_version])
     # Fetch and print the requested URL
- 
     try:
         http = urllib.PoolManager()
         thing = http.request('GET', url)


### PR DESCRIPTION
Potential fix for [https://github.com/PavliJuren/PV080_buggy_code/security/code-scanning/102](https://github.com/PavliJuren/PV080_buggy_code/security/code-scanning/102)

To fix the issue, we should avoid using `exec` to dynamically import modules. Instead, we can use a safer alternative, such as a dictionary mapping valid `urllib_version` values to their corresponding modules. This approach ensures that only explicitly allowed versions of `urllib` can be used, eliminating the risk of arbitrary code execution.

Steps to fix:
1. Replace the `exec` call with a dictionary that maps valid `urllib_version` values (e.g., "2" and "3") to their corresponding modules.
2. Validate the `urllib_version` parameter to ensure it matches one of the allowed keys in the dictionary.
3. Raise an error or return a safe response if the `urllib_version` parameter is invalid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
